### PR TITLE
added cmake files for easy inclusion for cmake projects

### DIFF
--- a/avtk/CMakeLists.txt
+++ b/avtk/CMakeLists.txt
@@ -1,0 +1,82 @@
+
+cmake_minimum_required(VERSION 2.8)
+
+find_package(PkgConfig)
+pkg_check_modules(CAIRO cairo REQUIRED)
+pkg_check_modules(SND sndfile )
+
+list(APPEND AVTK_INCLUDE_DIRS ${CAIRO_INCLUDE_DIRS} avtk ) #note this extra reference to avtk is for the parent dir, not here
+list(APPEND AVTK_LDFLAGS ${CAIRO_LDFLAGS} )
+
+list(APPEND AVTK_SND_SRC "")
+if(SND_FOUND)
+    add_definitions( "-DAVTK_SNDFILE" )
+    list(APPEND SND_SRC snd_utils.cxx)
+    list(APPEND AVTK_INCLUDE_DIRS ${SND_INCLUDE_DIRS} ) 
+    list(APPEND AVTK_LDFLAGS ${SND_LDFLAGS} )
+endif()
+
+#platform specific libs
+pkg_check_modules(X11 x11)
+pkg_check_modules(USER32 user32)
+pkg_check_modules(COCOA Cocoa)
+
+
+add_definitions( "-DPUGL_HAVE_CAIRO" )
+
+if(X11_FOUND)
+    list(APPEND PUGL_SRC pugl/pugl_x11.c )
+    list(APPEND AVTK_INCLUDE_DIRS ${X11_INCLUDE_DIRS} )
+    list(APPEND AVTK_LDFLAGS ${X11_LDFLAGS} )
+elseif(USER32_FOUND)
+    pkg_check_modules(OPENGL32 opengl32 REQUIRED )
+    pkg_check_modules(GLU32 glu32 REQUIRED )
+    pkg_check_modules(GDI32 gdi32 REQUIRED )
+    list(APPEND PUGL_SRC pugl/pugl_win.cpp ) 
+    list(APPEND AVTK_INCLUDE_DIRS ${USER32_INCLUDE_DIRS} ${OPENGL32_INCLUDE_DIRS} ${GLU32_INCLUDE_DIRS} ${GDI32_INCLUDE_DIRS} )
+    list(APPEND AVTK_LDFLAGS ${USER32_LDFLAGS} ${OPENGL32_LDFLAGS} ${GLU32_LDFLAGS} ${GDI32_LDFLAGS} )
+elseif(COCOA_FOUND)
+    pkg_check_modules(OPENGL OpenGL REQUIRED )
+    list(APPEND PUGL_SRC pugl/pugl_osx.m )  
+    list(APPEND AVTK_INCLUDE_DIRS ${COCOA32_INCLUDE_DIRS} ${OPENGL_INCLUDE_DIRS} )
+    list(APPEND AVTK_LDFLAGS ${COCOA32_LDFLAGS} ${OPENGL_LDFLAGS} )
+else()
+    message(SEND_ERROR "NO APPROPRIATE UI LIBRARY FOUND (x11, cocoa, nor user32)")
+
+endif()
+
+set(AVTK_INCLUDE_DIRS ${AVTK_INCLUDE_DIRS} PARENT_SCOPE)
+set(AVTK_LDFLAGS ${AVTK_LDFLAGS} PARENT_SCOPE)
+
+include_directories( ${AVTK_INCLUDE_DIRS} ../avtk pugl )
+
+
+add_library(avtk STATIC 
+    box.cxx
+    button.cxx
+    common.cxx
+    dial.cxx
+    dialog.cxx
+    envelope.cxx
+    eventeditor.cxx
+    filebrowser.cxx
+    group.cxx
+    helpers.cxx
+    image.cxx
+    list.cxx
+    listitem.cxx
+    midi.cxx
+    number.cxx
+    scroll.cxx
+    slider.cxx
+    spectrum.cxx
+    tester.cxx
+    text.cxx
+    theme.cxx
+    ui.cxx
+    utils.cxx
+    ${AVTK_SND_SRC}
+    waveform.cxx
+    widget.cxx
+    ${PUGL_SRC}
+)

--- a/avtk/snd_utils.hxx
+++ b/avtk/snd_utils.hxx
@@ -29,8 +29,8 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef OPENAV_AVTK_UTILS_HXX
-#define OPENAV_AVTK_UTILS_HXX
+#ifndef OPENAV_AVTK_SND_UTILS_HXX
+#define OPENAV_AVTK_SND_UTILS_HXX
 
 /** Utils
  * Utils provides a variety of utility functions that are cross-platform.
@@ -52,23 +52,6 @@
 namespace Avtk
 {
 int fileUpLevel( std::string path, std::string& newPath );
-
-int directories( std::string d, std::vector< std::string >& files, bool nameOnly = true, bool printErrors = true );
-
-/** lists the contents of a directory @param directory, and stores the
- * resuliting filenames in the provided @param output vector. The options are
- * provided to allow for better presentation of the contents:<br/>
- * - @param nameOnly (provides only file *name* without path).<br/>
- * - @param smartShortStrings (remove starting N characters if common in all files).<br/>
- * - @param printErrors (prints errors if file doesn't exist etc).
- */
-int directoryContents(  std::string directory,
-                        std::vector< std::string >& output,
-                        std::string& strippedFilenameStart,
-                        bool nameOnly = true,
-                        bool smartShortStrings = true,
-                        bool printErrors = true );
-};
-
+}
 #endif // OPENAV_AVTK_UTILS_HXX
 

--- a/avtk/snd_utils.hxx
+++ b/avtk/snd_utils.hxx
@@ -51,7 +51,7 @@
 
 namespace Avtk
 {
-int fileUpLevel( std::string path, std::string& newPath );
+int loadSample( std::string path, std::vector< float >& sample, bool printErrors = true );
 }
 #endif // OPENAV_AVTK_UTILS_HXX
 

--- a/avtk/utils.cxx
+++ b/avtk/utils.cxx
@@ -35,41 +35,9 @@
 #include "theme.hxx"
 #include <algorithm>
 #include <cstring>
-#include <sndfile.h>
 
 namespace Avtk
 {
-int loadSample( std::string path, std::vector< float >& sample, bool printErrors )
-{
-#ifdef AVTK_SNDFILE
-	SF_INFO info;
-	memset( &info, 0, sizeof( SF_INFO ) );
-	SNDFILE* const sndfile = sf_open( path.c_str(), SFM_READ, &info);
-	if ( !sndfile ) {
-		printf("Failed to open sample '%s'\n", path.c_str() );
-		return -1;
-	}
-
-	if( !(info.channels == 1 || info.channels == 2) ) {
-		int chnls = info.channels;
-		printf("Loading sample %s, channels = %i\n", path.c_str(), chnls );
-		return -1;
-	}
-
-	sample.resize( info.frames * info.channels );
-
-	sf_seek(sndfile, 0ul, SEEK_SET);
-	sf_read_float( sndfile, &sample[0], info.frames * info.channels );
-	sf_close(sndfile);
-
-	return OPENAV_OK;
-#else
-	if( printErrors ) {
-		printf("AVTK compiled without SNDFILE support: cannot load audio sample.\n");
-	}
-	return OPENAV_ERROR;
-#endif
-}
 
 int fileUpLevel( std::string path, std::string& newPath )
 {

--- a/exampleCMakeLists.txt
+++ b/exampleCMakeLists.txt
@@ -1,0 +1,17 @@
+#this is a template cmake file that you can use to easily add avtk to your cmake project
+cmake_minimum_required(VERSION 2.8)
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -g")
+
+#TO USE AVTK YOU JUST NEED TO DO 3 COMMANDS (2 here, 1 below your project)
+add_subdirectory(avtk)
+include_directories( ${AVTK_INCLUDE_DIRS} )
+
+# YOUR PROJECT SPECIFIC STUFF HERE
+add_executable(test_ui
+    test_ui.cxx
+    main.cxx
+)
+
+#THE FINAL COMMAND FOR AVTK
+target_link_libraries(test_ui avtk ${AVTK_LDFLAGS} )


### PR DESCRIPTION
I was going to test this more, but I thought I'd at least get the conversation going.
I haven't tested this for cross platform development, but theoretically it should work for windows and OSX. Its working well for me so far with simple example UI programs and makes libsndfile an optional dependency. The best is that its only 3 extra lines in my cmake file.

Let me know what you think and what could be improved.
Thanks!
