### PR TITLE
meson: Initial meson support as submodule

### DIFF
--- a/avtk/meson.build
+++ b/avtk/meson.build
@@ -1,0 +1,38 @@
+avtk_sources += files([
+  'box.cxx',
+  'button.cxx',
+  'common.cxx',
+  'dial.cxx',
+  'dialog.cxx',
+  'envelope.cxx',
+  'eventeditor.cxx',
+  'filebrowser.cxx',
+  'group.cxx',
+  'helpers.cxx',
+  'image.cxx',
+  'list.cxx',
+  'listitem.cxx',
+  'midi.cxx',
+  'number.cxx',
+  'rotary.cxx',
+  'scroll.cxx',
+  'slider.cxx',
+  'spectrum.cxx',
+  'tester.cxx',
+  'text.cxx',
+  'theme.cxx',
+  'ui.cxx',
+  'utils.cxx',
+  'waveform.cxx',
+  'widget.cxx',
+])
+
+avtk_incl += [
+  include_directories('.'),
+]
+
+subdir('pugl')
+
+avtk_sources += pugl_sources
+avtk_incl += pugl_incl
+avtk_c_args += pugl_c_args

--- a/avtk/pugl/meson.build
+++ b/avtk/pugl/meson.build
@@ -1,0 +1,12 @@
+pugl_sources = files([
+  'pugl_x11.c',
+])
+
+pugl_incl = [
+  include_directories('.'),
+]
+
+pugl_c_args = [
+  '-DPUGL_HAVE_CAIRO',
+# '-DPUGL_HAVE_GL',
+]

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,51 @@
+project(
+  'AVTK', 'c', 'cpp',
+  meson_version: '>= 0.47.0',
+# license: 'GPL-2.0-or-later',
+  version: '0.0.1',
+)
+
+# Versioning
+package_name = meson.project_name()
+package_version = meson.project_version()
+
+# Dependencies
+cairo_req = '>= 1.15.10'
+sndfile_req = '>= 1.0.28'
+x11_req = '>= 1.6.0'
+
+cairo_dep = dependency('cairo', version: cairo_req)
+sndfile_dep = dependency('sndfile', version: sndfile_req)
+x11_dep = dependency('x11', version: sndfile_req)
+
+# Build
+avtk_sources = []
+
+avtk_deps = [
+  cairo_dep,
+  sndfile_dep,
+  x11_dep,
+]
+
+avtk_incl = []
+avtk_c_args = []
+avtk_cpp_args = [
+  '-DAVTK_SNDFILE',
+]
+
+subdir('avtk')
+
+avtk_sta = static_library(
+  'avtk', avtk_sources,
+  dependencies: avtk_deps,
+  include_directories: avtk_incl,
+  c_args: avtk_c_args,
+  cpp_args: avtk_cpp_args,
+  install: false,
+)
+
+avtk_dep = declare_dependency(
+  link_with: avtk_sta,
+  include_directories: include_directories('avtk'),
+  dependencies: avtk_deps,
+)


### PR DESCRIPTION
This patch introduce minimal meson build scripts that should let AVTK being used as a [meson subproject](http://mesonbuild.com/Subprojects.html) for reverse dependencies that are themselves build with meson, like the [ArtyFX plugin bundle](https://github.com/openAVproductions/openAV-ArtyFX).